### PR TITLE
Implement API Authentication to Master

### DIFF
--- a/MapSite.Unit/APIKeyAuthenticationMiddlewareTest.cs
+++ b/MapSite.Unit/APIKeyAuthenticationMiddlewareTest.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using MapSite.Middleware;
+using MapSite.Services;
+using System.Net;
+
+namespace MapSite.Unit;
+
+internal sealed class APIKeyAuthenticationMiddlewareTest
+{
+    [Test]
+    public async Task Middleware_ReturnsUnauthorised_WhenRequestHasNoAPIKeyHeader()
+    {
+        // Arrange
+        const string APIPath = "/api";
+        const string ValidAPIKey = "VALID-KEY";
+        using var host = await StartHostWithMiddlewareWithAPIKeyAsync(ValidAPIKey);
+
+        // Act
+        var response = await host.GetTestClient().GetAsync(APIPath);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+    }
+
+    [Test]
+    public async Task Middleware_ReturnsUnauthorised_WhenRequestHasInvalidAPIKey()
+    {
+        // Arrange
+        const string APIPath = "/api";
+        const string ValidAPIKey = "VALID-KEY";
+        const string InvalidAPIKey = "INVALID-KEY";
+        using var host = await StartHostWithMiddlewareWithAPIKeyAsync(ValidAPIKey);
+        var testClient = SetupTestClientToHaveAPIKey(host, InvalidAPIKey);
+
+        // Act
+        var response = await testClient.GetAsync(APIPath);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+    }
+
+    [Test]
+    public async Task Middleware_ReturnsNotFound_WhenRequestHasValidAPIKey()
+    {
+        // Arrange
+        const string APIPath = "/api";
+        const string ValidAPIKey = "VALID-KEY";
+        using var host = await StartHostWithMiddlewareWithAPIKeyAsync(ValidAPIKey);
+        var testClient = SetupTestClientToHaveAPIKey(host, ValidAPIKey);
+        // Act
+        var response = await testClient.GetAsync(APIPath);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task Middleware_ReturnsNotFound_WhenRequestIsNotForAPI()
+    {
+        // Arrange
+        const string Path = "/";
+        const string ValidAPIKey = "VALID-KEY";
+        using var host = await StartHostWithMiddlewareWithAPIKeyAsync(ValidAPIKey);
+
+        // Act
+        var response = await host.GetTestClient().GetAsync(Path);
+
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    private async Task<IHost> StartHostWithMiddlewareWithAPIKeyAsync(string apiKey)
+    {
+        return await new HostBuilder().ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer()
+                    .ConfigureAppConfiguration((config) =>
+                    {
+                        var configDictionary = new Dictionary<string, string?>
+                        {
+                            { APIKey.SectionName, apiKey }
+                        };
+
+                        config.AddInMemoryCollection(configDictionary);
+                    })
+                    .ConfigureServices((services) =>
+                    {
+                        services.AddAPIKeyAuthenticationServices();
+                    })
+                    .Configure((app) =>
+                    {
+                        app.UseAPIKeyAuthentication();
+                    });
+            }).StartAsync();
+    }
+
+    private HttpClient SetupTestClientToHaveAPIKey(IHost host, string apiKey)
+    {
+        var testClient = host.GetTestClient();
+        testClient.DefaultRequestHeaders.Add(APIKey.SectionName, apiKey);
+        return testClient;
+    }
+}

--- a/MapSite.Unit/APIKeyAuthenticatorTest.cs
+++ b/MapSite.Unit/APIKeyAuthenticatorTest.cs
@@ -1,0 +1,82 @@
+﻿using MapSite.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace MapSite.Unit;
+
+// TODO: Use a test data generator for unit tests
+internal sealed class APIKeyAuthenticatorTest
+{
+    [Test]
+    public void IsRequestAuthenticated_WhenSuppliedInvalidAPIKey_ReturnsFalse()
+    {
+        // Arrange
+        const string InvalidAPIKey = "INVALID-KEY";
+        const string ValidAPIKey = "VALID-KEY";
+        var configuration = CreateConfigurationWithAPIKey(ValidAPIKey);
+        var request = CreateHttpRequestMockWithAPIKey(InvalidAPIKey);
+        var authenticator = CreateAuthenticatorWithConfiguration(configuration);
+
+        // Act
+        var isAuthenticated = authenticator.IsRequestAuthenticated(request.Object);
+
+        // Assert
+        Assert.That(isAuthenticated, Is.False);
+    }
+
+    [Test]
+    public void IsRequestAuthenticated_WhenSuppliedNullAPIKey_ReturnsFalse()
+    {
+        // Arrange
+        const string ValidAPIKey = "VALID-KEY";
+        var configuration = CreateConfigurationWithAPIKey(ValidAPIKey);
+        var request = CreateHttpRequestMockWithAPIKey(null!);
+        var authenticator = CreateAuthenticatorWithConfiguration(configuration);
+
+        // Act
+        var isAuthenticated = authenticator.IsRequestAuthenticated(request.Object);
+
+        // Assert
+        Assert.That(isAuthenticated, Is.False);
+    }
+
+    [Test]
+    public void IsRequestAuthenticated_WhenSuppliedValidAPIKey_ReturnsTrue()
+    {
+        // Arrange
+        const string ValidAPIKey = "VALID-KEY";
+        var configuration = CreateConfigurationWithAPIKey(ValidAPIKey);
+        var request = CreateHttpRequestMockWithAPIKey(ValidAPIKey);
+        var authenticator = CreateAuthenticatorWithConfiguration(configuration);
+
+        // Act
+        var isAuthenticated = authenticator.IsRequestAuthenticated(request.Object);
+
+        // Assert
+        Assert.That(isAuthenticated, Is.True);
+    }
+
+    private IConfiguration CreateConfigurationWithAPIKey(string apiKey)
+    {
+        var configurationDictionary = new Dictionary<string, string?>
+        {
+            { APIKey.SectionName, apiKey }
+        };
+
+        return new ConfigurationBuilder().AddInMemoryCollection(configurationDictionary).Build();
+    }
+
+    private Mock<HttpRequest> CreateHttpRequestMockWithAPIKey(string apiKey)
+    {
+        var requestMock = new Mock<HttpRequest>();
+        requestMock.SetupGet(x => x.Headers[APIKey.SectionName]).Returns(apiKey);
+        return requestMock;
+    }
+
+    private APIKeyAuthenticator CreateAuthenticatorWithConfiguration(IConfiguration configuration)
+    {
+        return new APIKeyAuthenticator(configuration, new NullLogger<APIKeyAuthenticator>());
+    }
+}

--- a/MapSite.Unit/MapSite.Unit.csproj
+++ b/MapSite.Unit/MapSite.Unit.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/MapSite/Middleware/APIKeyAuthenticationMiddleware.cs
+++ b/MapSite/Middleware/APIKeyAuthenticationMiddleware.cs
@@ -1,0 +1,49 @@
+﻿using MapSite.Services;
+using System.Net;
+
+namespace MapSite.Middleware;
+
+public sealed class APIKeyAuthenticationMiddleware
+{
+    public APIKeyAuthenticationMiddleware(RequestDelegate next, IAPIKeyAuthenticator authenticator)
+    {
+        _next = next;
+        _authenticator = authenticator;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!context.Request.Path.StartsWithSegments("/api"))
+        {
+            await _next.Invoke(context);
+            return;
+        }
+
+        if (!_authenticator.IsRequestAuthenticated(context.Request))
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+            return;
+        }
+
+        await _next.Invoke(context);
+    }
+
+    private readonly RequestDelegate _next;
+    private readonly IAPIKeyAuthenticator _authenticator;
+}
+
+public static class APIKeyAuthenticationMiddlewareExtensions
+{
+    static public IServiceCollection AddAPIKeyAuthenticationServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IAPIKeyAuthenticator, APIKeyAuthenticator>();
+
+        return services;
+    }
+
+    static public IApplicationBuilder UseAPIKeyAuthentication(this IApplicationBuilder app)
+    {
+        app.UseMiddleware<APIKeyAuthenticationMiddleware>();
+        return app;
+    }
+}

--- a/MapSite/Program.cs
+++ b/MapSite/Program.cs
@@ -1,9 +1,12 @@
 using Serilog;
+using MapSite.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+
+builder.Services.AddAPIKeyAuthenticationServices();
 
 builder.Host.UseSerilog((context, config) =>
 {
@@ -28,5 +31,7 @@ app.UseRouting();
 
 app.MapBlazorHub();
 app.MapFallbackToPage("/_Host");
+
+app.UseAPIKeyAuthentication();
 
 app.Run();

--- a/MapSite/Services/APIKeyAuthenticator.cs
+++ b/MapSite/Services/APIKeyAuthenticator.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace MapSite.Services;
+
+public sealed record APIKey(string Key)
+{
+    public const string SectionName = "API_KEY";
+}
+
+public interface IAPIKeyAuthenticator
+{
+    public bool IsRequestAuthenticated(HttpRequest request);
+}
+
+public sealed class APIKeyAuthenticator : IAPIKeyAuthenticator
+{
+    public APIKeyAuthenticator(IConfiguration configuration, ILogger<APIKeyAuthenticator> logger)
+    {
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public bool IsRequestAuthenticated(HttpRequest request)
+    {
+        var validAPIKey = _configuration.GetValue<string>(APIKey.SectionName);
+        var requestAPIKey = GetAPIKeyFromRequest(request);
+        if (requestAPIKey is null || validAPIKey != requestAPIKey)
+        {
+            _logger.LogWarning("An invalid key {InvalidAPIKey} was used for API {APIPath}", requestAPIKey, request.Path);
+            return false;
+        }
+
+        _logger.LogInformation("A valid key {ValidAPIKey} was used for API {APIPath}", requestAPIKey, request.Path);
+        return true;
+    }
+
+    private string? GetAPIKeyFromRequest(HttpRequest request)
+    {
+        return request.Headers[APIKey.SectionName];
+    }
+
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<APIKeyAuthenticator> _logger;
+}


### PR DESCRIPTION
We check if the API_KEY header is set in the request header. If it is the valid API key then the request is authorised. Otherwise, it will return unauthorised.

This middleware only runs on paths starting with "/api".